### PR TITLE
Update 1.2.7 (For numpy 2.0.0)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
   run:
     - python
     - mkl
-    - numpy
+    - numpy >=1.16
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,10 @@ requirements:
 
 test:
   commands:
+    - pip check
     - pytest --pyargs mkl_random
   requires:
+    - pip
     - pytest
     - mkl-service
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - wheel
     - mkl-devel  {{ mkl }}
     - cython 3
-    - numpy-base 2.0.0
+    - numpy-base >=1.16
   run:
     - python
     - mkl
@@ -37,13 +37,11 @@ requirements:
 
 test:
   commands:
-    - pip check
-    # nose is incompatible with python 3.12
-    - nosetests -v -e test_hypergeometric mkl_random   # [py<312]
+    - pytest --pyargs mkl_random
   requires:
-    - pip
-    - nose                                             # [py<312]
     - pytest
+    - mkl-service
+    - numpy
   imports:
     - mkl_random
     - mkl_random.mklrand

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [not x86]
-  skip: True  # [py<39]
+  skip: True  # [py<39 os osx]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
   script_env:
     - MKLROOT={{PREFIX}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [not x86]
-  skip: True  # [py<39 os osx]
+  skip: True  # [py<39 or osx]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
   script_env:
     - MKLROOT={{PREFIX}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [not x86]
+  skip: True  # [py<39 or py>=313]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
   script_env:
     - MKLROOT={{PREFIX}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,6 @@ requirements:
     - mkl-devel  {{ mkl }}
     - cython 3
     - numpy-base 2.0.0
-    - numpy >=1.16
   run:
     - python
     - mkl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - wheel
     - mkl-devel  {{ mkl }}
     - cython 3
-    - numpy-base >=1.16
+    - numpy-base {{ numpy }}
   run:
     - python
     - mkl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [not x86]
-  skip: True  # [py<37]
+  skip: True  # [py<39]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
   script_env:
     - MKLROOT={{PREFIX}}
@@ -29,7 +29,7 @@ requirements:
     - wheel
     - mkl-devel  {{ mkl }}
     - cython 3
-    - numpy-base {{ numpy }}
+    - numpy >=1.16
   run:
     - python
     - mkl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [not x86]
-  skip: True  # [py<39 or py>=313]
+  skip: True  # [py<37]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
   script_env:
     - MKLROOT={{PREFIX}}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,11 @@ requirements:
     - mkl-devel  {{ mkl }}
     - cython 3
     - numpy-base 2.0.0
+    - numpy >=1.16
   run:
     - python
     - mkl
-    - numpy >=1.16
+    - numpy
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,11 +29,11 @@ requirements:
     - wheel
     - mkl-devel  {{ mkl }}
     - cython 3
-    - numpy >=1.16
+    - numpy-base 2.0.0
   run:
     - python
     - mkl
-    - {{ pin_compatible('numpy') }}
+    - numpy >=1.16
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ test:
   requires:
     - pip
     - nose                                             # [py<312]
+    - pytest
   imports:
     - mkl_random
     - mkl_random.mklrand

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.4" %}
+{% set version = "1.2.7" %}
 
 package:
   name: mkl_random
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/IntelPython/mkl_random/archive/v{{ version }}.tar.gz
-  sha256: 9161eee81fbf27934eac1bc0d26ad3b933a582721fa66fe87e930ff2e9867c52
+  sha256: b6d39f4847921b6603201a491225b086aa75a1c1667ea7068b8813e0514133f7
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python
@@ -28,7 +29,7 @@ requirements:
     - wheel
     - mkl-devel  {{ mkl }}
     - cython 3
-    - numpy-base {{ numpy }}
+    - numpy-base 2.0.0
   run:
     - python
     - mkl


### PR DESCRIPTION
mkl_random 1.2.7

**Destination channel:**  defaults

### Links

- [PKG-5572](https://anaconda.atlassian.net/browse/PKG-5572) 
- [Upstream repository](https://github.com/IntelPython/mkl_random)
- [Upstream changelog/diff](https://github.com/IntelPython/mkl_random/releases/tag/v1.2.7)
- Relevant dependency PRs:
  - numpy 2.0 (non-base) for 64bit platforms

### Explanation of changes:

- update tests and update version and numpy-base lower bound and python version 


[PKG-5572]: https://anaconda.atlassian.net/browse/PKG-5572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ