### PR TITLE
update to 1.2.8

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,12 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
 
+# the conda build parameters to use
+build_parameters:
+  - "--suppress-variables"
+  - "--skip-existing"
+  - "--error-overlinking"
+  - "--no-test"
+
 channels:
   - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/abe832a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/abe832a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.7" %}
+{% set version = "1.2.8" %}
 
 package:
   name: mkl_random
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/IntelPython/mkl_random/archive/v{{ version }}.tar.gz
-  sha256: b6d39f4847921b6603201a491225b086aa75a1c1667ea7068b8813e0514133f7
+  sha256: b15a7f65903470ee96de05360886c2e3327a6a2f178aeba74405e2e627d7820c
 
 build:
   number: 0
@@ -29,7 +29,7 @@ requirements:
     - wheel
     - mkl-devel  {{ mkl }}
     - cython 3
-    - numpy-base 2.0.0
+    - numpy-base 2
   run:
     - python
     - mkl


### PR DESCRIPTION
mkl_random 1.2.8

**Destination channel:** main

### Links

- PKG-5918
- https://github.com/IntelPython/mkl_random/compare/v1.2.7...v1.2.8

### Explanation of changes:

- For numpy 2.1 py313 -  tests are skipped because of the circular dependency with numpy.
