### PR TITLE
ensure mkl 2025

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,8 @@
+# Required for glibc >= 2.26 for intel-openmp to work.
+pkg_build_image_tag: main-rockylinux-8
+
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_GLIBC: "2.28"
 
 # the conda build parameters to use
 build_parameters:
@@ -9,4 +12,7 @@ build_parameters:
   - "--no-test"
 
 channels:
-  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr95/abe832a
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr101/7a39196
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr102/8d3cf79
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr103/7538eef
+  - brianwing

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,17 +9,18 @@ source:
   sha256: b15a7f65903470ee96de05360886c2e3327a6a2f178aeba74405e2e627d7820c
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not x86]
   skip: True  # [py<39 or osx]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
   script_env:
-    - MKLROOT={{PREFIX}}
+    - MKLROOT={{ PREFIX }}
   ignore_run_exports:
     - blas
 
 requirements:
   build:
+    - {{ stdlib('c') }}  # [linux]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
@@ -27,13 +28,13 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - mkl-devel  {{ mkl }}
+    - mkl-devel 2025.*
     - cython 3
     - numpy-base 2
   run:
     - python
     - mkl
-    - numpy >=1.16
+    - numpy >=1.16,<3
 
 test:
   commands:
@@ -59,5 +60,7 @@ about:
   doc_url: https://github.com/IntelPython/mkl_random
 
 extra:
+  skip-lints:
+    - cbc_dep_in_run_missing_from_host
   recipe-maintainers:
     - oleksandr-pavlyk


### PR DESCRIPTION
mkl_random 1.2.8 b1

**Destination channel:** defaults

### Links

- [PKG-7073](https://anaconda.atlassian.net/browse/PKG-7073)
- [Upstream repository](https://github.com/IntelPython/mkl_random/tree/v1.2.8)
- Relevant dependency PRs:
  - AnacondaRecipes/intel_repack-feedstock#26
  - AnacondaRecipes/mkl-service-feedstock#6
  - AnacondaRecipes/numpy-feedstock#101



[PKG-7073]: https://anaconda.atlassian.net/browse/PKG-7073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ