### PR TITLE
mkl_random 1.3.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,6 @@
 # Required for glibc >= 2.26 for intel-openmp to work.
 pkg_build_image_tag: main-rockylinux-8
-
 build_env_vars:
-  ANACONDA_ROCKET_GLIBC: "2.28"
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 # the conda build parameters to use

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,6 +3,7 @@ pkg_build_image_tag: main-rockylinux-8
 
 build_env_vars:
   ANACONDA_ROCKET_GLIBC: "2.28"
+  ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 # the conda build parameters to use
 build_parameters:

--- a/recipe/0001-fix-pyproject-toml.patch
+++ b/recipe/0001-fix-pyproject-toml.patch
@@ -1,7 +1,7 @@
 From e8295d1ede07d8586ec79308e42d84ad5fed8fd9 Thu Oct 23 14:14:42 2025
 From: Serhii Kupriienko
 Date: Thu, 23 Oct 2025 14:14:42 +0300
-Subject: [PATCH] Fix setuptools, license, python constraint, and mkl->mkl-service
+Subject: [PATCH] Fix setuptools, license, python constraint
 
 ---
  pyproject.toml | 8 ++++----
@@ -25,7 +25,7 @@ index 1e24356..b279bca 100644
      "Operating System :: Unix"
  ]
 -dependencies = ["numpy >=1.26.4", "mkl"]
-+dependencies = ["numpy >=1.26.4", "mkl-service"]
++dependencies = ["numpy >=1.26.4"]
  description = "NumPy-based Python interface to Intel (R) MKL Random Number Generation functionality"
  dynamic = ["version"]
  keywords = ["MKL", "VSL", "true randomness", "pseudorandomness",

--- a/recipe/0001-fix-pyproject-toml.patch
+++ b/recipe/0001-fix-pyproject-toml.patch
@@ -1,15 +1,14 @@
-From 80cf2b9462535e5265c41d0b0c97f33df835d786 Thu Oct 23 13:49:27 2025
+From e8295d1ede07d8586ec79308e42d84ad5fed8fd9 Thu Oct 23 14:14:42 2025
 From: Serhii Kupriienko
-Date: Thu, 23 Oct 2025 13:49:27 +0300
-Subject: [PATCH] Fix pyproject.toml license format and python version
- constraint
+Date: Thu, 23 Oct 2025 14:14:42 +0300
+Subject: [PATCH] Fix setuptools, license, python constraint, and mkl->mkl-service
 
 ---
- pyproject.toml | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ pyproject.toml | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
 
 diff --git a/pyproject.toml b/pyproject.toml
-index 1e24356..eeb1375 100644
+index 1e24356..b279bca 100644
 --- a/pyproject.toml
 +++ b/pyproject.toml
 @@ -25,7 +25,7 @@
@@ -21,7 +20,14 @@ index 1e24356..eeb1375 100644
  
  [project]
  authors = [
-@@ -56,10 +56,10 @@ dynamic = ["version"]
+@@ -50,16 +50,16 @@ classifiers = [
+     "Operating System :: POSIX",
+     "Operating System :: Unix"
+ ]
+-dependencies = ["numpy >=1.26.4", "mkl"]
++dependencies = ["numpy >=1.26.4", "mkl-service"]
+ description = "NumPy-based Python interface to Intel (R) MKL Random Number Generation functionality"
+ dynamic = ["version"]
  keywords = ["MKL", "VSL", "true randomness", "pseudorandomness",
              "Philox", "MT-19937", "SFMT-19937", "MT-2203", "ARS-5",
              "R-250", "MCG-31"]

--- a/recipe/0001-fix-pyproject-toml.patch
+++ b/recipe/0001-fix-pyproject-toml.patch
@@ -1,0 +1,39 @@
+From 80cf2b9462535e5265c41d0b0c97f33df835d786 Thu Oct 23 13:49:27 2025
+From: Serhii Kupriienko
+Date: Thu, 23 Oct 2025 13:49:27 +0300
+Subject: [PATCH] Fix pyproject.toml license format and python version
+ constraint
+
+---
+ pyproject.toml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 1e24356..eeb1375 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -25,7 +25,7 @@
+ 
+ [build-system]
+ build-backend = "setuptools.build_meta"
+-requires = ["setuptools>=77", "Cython", "numpy"]
++requires = ["setuptools>=64", "Cython", "numpy"]
+ 
+ [project]
+ authors = [
+@@ -56,10 +56,10 @@ dynamic = ["version"]
+ keywords = ["MKL", "VSL", "true randomness", "pseudorandomness",
+             "Philox", "MT-19937", "SFMT-19937", "MT-2203", "ARS-5",
+             "R-250", "MCG-31"]
+-license = "BSD-3-Clause"
++license = {text = "BSD-3-Clause"}
+ name = "mkl_random"
+ readme = {file = "README.md", content-type = "text/markdown"}
+-requires-python = ">=3.9,<3.14"
++requires-python = ">=3.9,<3.15"
+ 
+ [project.optional-dependencies]
+ test = ["pytest"]
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,24 +25,22 @@ build:
 
 requirements:
   build:
-    - {{ stdlib('c') }}  # [linux]
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
     - python
     - cython 3
     - mkl-devel 2025.*
-    - numpy-base >=2.3,<3
+    - numpy-base {{ numpy }}
     - pip
     # numpy-base 2.3.3 requires setuptools <74
     # The patch changes license format to {text = "BSD"} which works with setuptools <74
     - setuptools >=64,<74
-    - wheel
   run:
     - python
     - mkl
-    - mkl-service
-    - numpy >=1.16,<3
+    - numpy >=1.26.4,<3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,21 @@
-{% set version = "1.2.8" %}
+{% set version = "1.3.0" %}
 
 package:
   name: mkl_random
   version: {{ version }}
 
 source:
-  url: https://github.com/IntelPython/mkl_random/archive/v{{ version }}.tar.gz
-  sha256: b15a7f65903470ee96de05360886c2e3327a6a2f178aeba74405e2e627d7820c
+  url: https://github.com/IntelPython/mkl_random/archive/{{ version }}.tar.gz
+  sha256: 4f4d6ee649e694eb94bc0a039f4db259d329a901bc706cb1648c41ebfa96d35e
+  patches:
+    - 0001-fix-pyproject-toml.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not x86]
-  skip: True  # [py<39 or osx]
-  script: {{PYTHON}} -m pip install --no-build-isolation --no-deps .
+  # numpy-base 2.3.0 no longer supports Python 3.10: https://numpy.org/devdocs/release/2.3.0-notes.html
+  skip: True  # [py<311 or osx]
+  script: {{PYTHON}} -m pip install --no-build-isolation --no-deps . -vv
   script_env:
     - MKLROOT={{ PREFIX }}
   ignore_run_exports:
@@ -25,12 +28,14 @@ requirements:
     - {{ compiler('cxx') }}
   host:
     - python
-    - pip
-    - setuptools
-    - wheel
-    - mkl-devel 2025.*
     - cython 3
-    - numpy-base 2
+    - mkl-devel 2025.*
+    - numpy-base >=2.3,<3
+    - pip
+    # numpy-base 2.3.3 requires setuptools <74
+    # The patch changes license format to {text = "BSD"} which works with setuptools <74
+    - setuptools >=64,<74
+    - wheel
   run:
     - python
     - mkl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,8 +15,7 @@ source:
 build:
   number: 0
   skip: true  # [not x86]
-  # numpy-base 2.3.0 no longer supports Python 3.10: https://numpy.org/devdocs/release/2.3.0-notes.html
-  skip: True  # [py<311 or osx]
+  skip: True  # [py<39 or osx]
   script: {{PYTHON}} -m pip install --no-build-isolation --no-deps . -vv
   script_env:
     - MKLROOT={{ PREFIX }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
   url: https://github.com/IntelPython/mkl_random/archive/{{ version }}.tar.gz
   sha256: 4f4d6ee649e694eb94bc0a039f4db259d329a901bc706cb1648c41ebfa96d35e
   patches:
+    # 1) Fix pyproject.toml license format and python version constraint
+    # 2) pyproject.toml shows dependency on mkl, which we call mkl-service in conda...
     - 0001-fix-pyproject-toml.patch
 
 build:
@@ -39,20 +41,19 @@ requirements:
   run:
     - python
     - mkl
+    - mkl-service
     - numpy >=1.16,<3
 
 test:
-  commands:
-    - pip check
-    - pytest --pyargs mkl_random
-  requires:
-    - pip
-    - pytest
-    - mkl-service
-    - numpy
   imports:
     - mkl_random
     - mkl_random.mklrand
+  requires:
+    - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest --pyargs mkl_random
 
 about:
   home: https://github.com/IntelPython/mkl_random


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10207](https://anaconda.atlassian.net/browse/PKG-10207)
- [Upstream repository](https://github.com/IntelPython/mkl_random/blob/1.3.0/pyproject.toml)
- Relevant dependency PRs:
  - AnacondaRecipes/numpy-feedstock#120

### Explanation of changes:

- Add a patch to fix pyproject.toml license format, setuptools, and python version constraint. It needed:
  - because numpy-base 2.3.0 has the setuptools <74 runtime dependency.
  - replace mkl with mkl-service (it's our conda package name)
  - setuptools >=77 is incompatible with an old pyproject.license format
  - bump the upper bound of Python to <3.15
- Skip py<311 because numpy-base 2.3.0 no longer supports Python 3.10: https://numpy.org/devdocs/release/2.3.0-notes.html
- Add mkl-service to run
- Use `ANACONDA_ROCKET_ENABLE_PY314 : yes`

### Notes:

- linux-64 and win-64 have been built on dev machines with `--no-test` because it has numpy as a cyclic dependency

[PKG-10207]: https://anaconda.atlassian.net/browse/PKG-10207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ